### PR TITLE
Use single duty range for both test directions

### DIFF
--- a/ACH_calculator.py
+++ b/ACH_calculator.py
@@ -10,27 +10,33 @@ DEFAULT_COEFFICIENTS = {
     "none": {
         "forward": {"slope": 9.21069, "intercept": 935.46713},
         "reverse": {"slope": 9.21069, "intercept": 935.46713},
+        "duty_range": [20, 100],
     },
     "low": {
         "forward": {"slope": 7.36855, "intercept": 748.3737},
         "reverse": {"slope": 7.36855, "intercept": 748.3737},
+        "duty_range": [20, 100],
     },
     "high": {
         "forward": {"slope": 5.52641, "intercept": 561.2803},
         "reverse": {"slope": 5.52641, "intercept": 561.2803},
+        "duty_range": [20, 100],
     },
 }
 
 
 def load_fan_coefficients(file_path="fan_coefficients.json"):
     """Load fan calibration coefficients from a JSON file."""
+    coeffs = {k: v.copy() for k, v in DEFAULT_COEFFICIENTS.items()}
     if os.path.exists(file_path):
         with open(file_path, "r") as f:
             try:
-                return json.load(f)
+                data = json.load(f)
             except json.JSONDecodeError:
-                pass
-    return DEFAULT_COEFFICIENTS
+                data = {}
+        for cover, values in data.items():
+            coeffs.setdefault(cover, {}).update(values)
+    return coeffs
 
 
 '''
@@ -59,7 +65,7 @@ class BlowerDoorTestCalculator:
         # 계산 결과 저장을 위한 변수
         self.val = dict()
         # PWM duty to Volumetric Flow rate calculation
-        # OF-OD172SAP-Reversible Fan에만 해당하는 값임
+        # 9GV2048P0G201 fan only (formerly OF-OD172SAP-Reversible)
         self.cover = measured_data.get("fan_cover", "none").lower()
         self.num_fans = int(measured_data.get("fan_count", 2))
 

--- a/fan_coefficients.json
+++ b/fan_coefficients.json
@@ -1,14 +1,17 @@
 {
     "none": {
         "forward": {"slope": 9.21069, "intercept": 935.46713},
-        "reverse": {"slope": 9.21069, "intercept": 935.46713}
+        "reverse": {"slope": 9.21069, "intercept": 935.46713},
+        "duty_range": [20, 100]
     },
     "low": {
         "forward": {"slope": 7.36855, "intercept": 748.3737},
-        "reverse": {"slope": 7.36855, "intercept": 748.3737}
+        "reverse": {"slope": 7.36855, "intercept": 748.3737},
+        "duty_range": [20, 100]
     },
     "high": {
         "forward": {"slope": 5.52641, "intercept": 561.2803},
-        "reverse": {"slope": 5.52641, "intercept": 561.2803}
+        "reverse": {"slope": 5.52641, "intercept": 561.2803},
+        "duty_range": [20, 100]
     }
 }

--- a/user_interface.py
+++ b/user_interface.py
@@ -381,16 +381,18 @@ class BackgroundTask(QThread):
     def blower_door_test(self, test):
 
         # 측정 모드에 따른 변수 설정
-        # OF-OD172SAP-Reversible 팬에만 해당하는 값임
-        zero_duty = 50
-        if test == "depressurization":
-            # PWM 55~90
-            min_duty, max_duty = 55, 90
-            initial_duty = 56
-        elif test == "pressurization":
-            # PWM 10~45
-            min_duty, max_duty = 45, 10
-            initial_duty = 44
+        # 9GV2048P0G201 fan only (formerly OF-OD172SAP-Reversible)
+        zero_duty = 0
+
+        with open('conditions.json', 'r') as f:
+            conditions = json.load(f)
+        cover = conditions.get("fan_cover", "none").lower()
+        fan_coeffs = ACH_calculator.load_fan_coefficients()
+        coeff = fan_coeffs.get(cover, fan_coeffs.get("none", {}))
+
+        duty_range = coeff.get("duty_range", [20, 100])
+        min_duty, max_duty = duty_range
+        initial_duty = min_duty - 1
 
         # 측정
         measuring = {}


### PR DESCRIPTION
## Summary
- consolidate fan coefficient duty range into a single value shared by both tests
- update coefficient loader defaults
- use the shared range during blower door tests
- zero duty is now 0 for 9GV2048P0G201 fan and initial duty starts one below the min

## Testing
- `python -m py_compile ACH_calculator.py user_interface.py pwm_pid_control.py sensor_and_controller.py reporting.py graph_plotter.py`


------
https://chatgpt.com/codex/tasks/task_e_684a1dab0da08332a8420b6e881a23ed