### PR TITLE
Add Raspberry Pi desktop shortcut instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,3 +57,26 @@ To control the fan using `pigpio` on a Raspberry Pi:
    sudo python3 user_interface.py
    ```
 
+## GUI Launch Shortcut on Raspberry Pi
+To start the GUI by double-clicking on the desktop:
+
+1. Ensure `user_interface.py` is executable:
+   ```bash
+   chmod +x /home/pi/Blower_Door_Test_Calculator/user_interface.py
+   ```
+2. Create `~/Desktop/user_interface.desktop` with the following content (update paths as needed):
+   ```ini
+   [Desktop Entry]
+   Type=Application
+   Name=BlowerDoorTest
+   Comment=Run blower door test GUI
+   Exec=sudo /usr/bin/python3 /home/pi/Blower_Door_Test_Calculator/user_interface.py
+   Icon=/home/pi/Blower_Door_Test_Calculator/icon.png
+   Terminal=true
+   ```
+3. Make it executable:
+   ```bash
+   chmod +x ~/Desktop/user_interface.desktop
+   ```
+Double-click the icon to run the GUI with root privileges.
+

--- a/user_interface.desktop
+++ b/user_interface.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=BlowerDoorTest
+Comment=Run blower door test GUI
+Exec=sudo /usr/bin/python3 /home/pi/Blower_Door_Test_Calculator/user_interface.py
+Icon=/home/pi/Blower_Door_Test_Calculator/icon.png
+Terminal=true
+

--- a/user_interface.py
+++ b/user_interface.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import sys
 import json


### PR DESCRIPTION
## Summary
- document how to launch the GUI with a `.desktop` shortcut
- include example `user_interface.desktop` file
- make `user_interface.py` directly executable

## Testing
- `python3 -m py_compile ACH_calculator.py graph_plotter.py reporting.py pwm_pid_control.py sensor_and_controller.py user_interface.py`


------
https://chatgpt.com/codex/tasks/task_e_684b579004908332813b2fa0adedacfb