### PR TITLE
Fix README math formulas

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -80,3 +80,35 @@ To start the GUI by double-clicking on the desktop:
    ```
 Double-click the icon to run the GUI with root privileges.
 
+
+## Calculation and Execution Flow
+The program automates a full blower door test using several helper modules:
+
+1. `user_interface.py` gathers initial parameters and guides the measurement.
+2. `sensor_and_controller.py` communicates with the sensors and fan controller to record pressure differences.
+3. `pwm_pid_control.py` maintains target pressures using PID control of the fan.
+4. `ACH_calculator.py` computes flow coefficients from the collected data and derives values such as Q50, ACH50 and leakage area.
+5. `graph_plotter.py` plots pressure versus flow on a log–log scale and saves an image.
+6. `reporting.py` fills an Excel template with the results and embeds the graph.
+
+Running `python user_interface.py` executes these steps sequentially. Measurement data are stored as JSON, then processed to produce a final Excel/PDF report along with graphs for documentation.
+
+
+## ACH_calculator Derivation
+`ACH_calculator.py` fits the measured data to the power-law model:
+
+$$
+\dot{V} = C_0\,\Delta P^n
+$$
+
+The steps are:
+1. Convert each pressure difference $\Delta P$ and flow rate $\dot{V}$ to natural-log form. Least-squares regression of $\ln\Delta P$ versus $\ln\dot{V}$ yields the exponent $n$ and intercept $\ln C$.
+2. Compute air density and viscosity from temperature, humidity and barometric pressure. These correct $C$ to $C_0$ via
+   $\displaystyle \frac{C_0}{C} = \left( \frac{\mu}{\mu_{\text{STP}}} \right)^{2n-1} \left( \frac{\rho}{\rho_{\text{STP}}} \right)^{1-n}$.
+3. Estimate the standard errors of `n` and `ln(C)` and apply the Student t-distribution to provide 95% confidence limits.
+4. Use the resulting coefficients to compute
+   * `Q50` – the volumetric flow rate at 50 Pa,
+   * `ACH50` – air changes per hour based on the interior volume, and
+   * `AL50` – effective leakage area at 50 Pa.
+
+The module also returns prediction bounds and `R^2` so the report includes uncertainty metrics.


### PR DESCRIPTION
## Summary
- update ACH derivation section math formatting so equations render correctly

## Testing
- `python -m py_compile ACH_calculator.py graph_plotter.py sensor_and_controller.py pwm_pid_control.py reporting.py user_interface.py`


------
https://chatgpt.com/codex/tasks/task_e_684b6cd563bc83328437b9036e0db84a