### PR TITLE
Ensure fan PWM duty is zero on startup

### DIFF
--- a/user_interface.py
+++ b/user_interface.py
@@ -616,6 +616,10 @@ class BackgroundTask(QThread):
 
 
 if __name__ == '__main__':
+    # Ensure the fan PWM duty is zero on startup so that the fan does not run
+    # even if powered. This provides a safe default state before any test begins.
+    sensor_and_controller.duty_set(0, test=test_mode)
+
     app = QApplication(sys.argv)
 
     # 창 사이즈 설정


### PR DESCRIPTION
## Summary
- set PWM duty to zero when `user_interface.py` starts so that the fan stays off if powered

## Testing
- `python -m py_compile user_interface.py sensor_and_controller.py`

------
https://chatgpt.com/codex/tasks/task_e_684e76abcf8483329905c89420fb30e1